### PR TITLE
feat(README): add configuration section with default settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,16 @@ use {
 }
 ```
 
+## Configuration
+
+Default settings:
+
+```lua
+{
+    onstart = false,
+    auto_change = false,
+    auto_change_time = 10,
+    auto_change_random = true,
+    border = false,
+}
+```


### PR DESCRIPTION
The code structure is quite simple, and the setup isn't complex at all. It shouldn't take much effort to remember to update the default settings when necessary. 

But adding this PR requires keeping the README updated. If you think you might forget or don't want to add things to worry about, I've seen in other plugins that they link the setup so that users can see the default config directly from the code.

Idk if other things can be doned to accomplish that.






